### PR TITLE
Fix building on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,22 @@ DBGFLAGS=-g -DDBG
 
 PREFIX = /usr/local
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	CXXFLAGS += -DLINUX
+endif
+ifeq ($(UNAME_S),Darwin)
+	CXX=g++-13 -std=c++11
+	CXXFLAGS += -DMAC
+	INCFLAGS += -I/opt/homebrew/include -L/opt/homebrew/lib
+endif
+
 %.d: %.cpp
 	$(CXX) $(INCFLAGS) -MM -MF $@ -MT $@ -MT $*.o $<
 
 all: linux
 
 linux: ext=
-linux: CXXFLAGS += -DLINUX
 linux: bin
 
 # Requires mingw-w64

--- a/README.md
+++ b/README.md
@@ -22,10 +22,28 @@ However, here are a few crucial pointers for those preferring to dive right in:
 * After achieving your chosen aim, you must become Guildmaster to win the game.
 
 ## Dependencies
+
 * libsdl2
 * libsdl2-image
 * libsdl2-mixer
 * libsdl2-ttf
+
+### Mac
+
+Install [Homebrew](https://brew.sh/).
+
+```bash
+# Install dependencies
+brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf
+
+# Build using Makefile, which is OS-agnostic and supports Mac M1.
+make install
+
+# Installed in /usr/local, which should be added to PATH.
+
+# Run
+exodus
+```
 
 ## Credits
 Thanks go to Artex Software for having originally created this excellent game, and to Jan Klose for granting permission to use the original graphical and audio assets, and for his support of this project.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install [Homebrew](https://brew.sh/).
 
 ```bash
 # Install dependencies
-brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf
+brew install g++ sdl2 sdl2_image sdl2_mixer sdl2_ttf
 
 # Build using Makefile, which is OS-agnostic and supports Mac M1.
 make install

--- a/src/mode/galaxy_map.cpp
+++ b/src/mode/galaxy_map.cpp
@@ -1991,7 +1991,7 @@ ExodusMode GalaxyMap::month_pass_update() {
             Player *p = exostate.set_active_player(mp_state.mp_player_idx);
             if (p && p->is_participating()) {
                 Officer &o = mp_state.mp_officer;
-                for (; o < OFF_MAX; o = (Officer)((int)o + 1)) {
+                for (; o < OFFICER_MAX; o = (Officer)((int)o + 1)) {
                     int cost = p->get_officer_cost(o);
                     if (cost <= 0) {
                         continue;

--- a/src/platform.h
+++ b/src/platform.h
@@ -27,6 +27,11 @@
 #define SAVEMANAGER SaveManagerLinux
 #endif
 
+#ifdef MAC
+#define TIMER TimerChrono
+#define SAVEMANAGER SaveManagerLinux
+#endif
+
 #ifdef WINDOWS
 #define TIMER TimerChrono
 #define SAVEMANAGER SaveManagerWindows

--- a/src/player/player.cpp
+++ b/src/player/player.cpp
@@ -636,8 +636,8 @@ void Player::set_tax(int t) {
 }
 
 OfficerQuality Player::get_officer(Officer off) {
-    if (off >= OFF_MAX) {
-        L.fatal("Requested invalid officer %d (max is %d)", off, OFF_MAX-1);
+    if (off >= OFFICER_MAX) {
+        L.fatal("Requested invalid officer %d (max is %d)", off, OFFICER_MAX-1);
     }
     return officers[off];
 }
@@ -660,15 +660,15 @@ int Player::get_officer_initial_cost(OfficerQuality q) {
 
 int Player::get_total_officer_costs() {
     int total = 0;
-    for (int i = 0; i < (int)OFF_MAX; ++i) {
+    for (int i = 0; i < (int)OFFICER_MAX; ++i) {
         total += get_officer_cost((Officer)i);
     }
     return total;
 }
 
 void Player::set_officer(Officer off, OfficerQuality off_q) {
-    if (off >= OFF_MAX) {
-        L.fatal("Setting invalid officer %d (max is %d)", off, OFF_MAX-1);
+    if (off >= OFFICER_MAX) {
+        L.fatal("Setting invalid officer %d (max is %d)", off, OFFICER_MAX-1);
     }
     if (off_q >= OFFQ_MAX) {
         L.fatal("Setting invalid officer quality %d (max is %d)", off, OFFQ_MAX-1);

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -162,7 +162,7 @@ enum Officer {
     OFF_Battle,
     OFF_Secret,
     OFF_Counsellor,
-    OFF_MAX
+    OFFICER_MAX
 };
 
 enum OfficerQuality {
@@ -390,7 +390,7 @@ class Player {
         void refresh_full_name();
         bool guild_member;
         int tax;  // Orig: t%
-        OfficerQuality officers[OFF_MAX];  // Orig: Ps%
+        OfficerQuality officers[OFFICER_MAX];  // Orig: Ps%
         Mission mission;
         StarMarker star_markers[N_MARKERS];
 

--- a/src/save/save.h
+++ b/src/save/save.h
@@ -32,6 +32,10 @@ class SaveManager {
 #include "save.linux.h"
 #endif
 
+#ifdef MAC
+#include "save.linux.h"
+#endif
+
 #ifdef WINDOWS
 #include "save.windows.h"
 #endif

--- a/src/save/save.linux.cpp
+++ b/src/save/save.linux.cpp
@@ -1,4 +1,4 @@
-#ifdef LINUX
+#if defined(LINUX) || defined(MAC)
 
 #include "save.linux.h"
 

--- a/src/state/exodus_state.cpp
+++ b/src/state/exodus_state.cpp
@@ -173,7 +173,7 @@ void ExodusState::init(GameConfig config) {
         players[i].set_tactic(0);
         players[i].nopirates = 0;
         set_random_hostility(players[i]);
-        for (int j = 0; j < OFF_MAX; ++j) {
+        for (int j = 0; j < OFFICER_MAX; ++j) {
             players[i].set_officer((Officer)j, OFFQ_Poor);
         }
         players[i].infraction_mask = 0;

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -14,6 +14,10 @@ class Timer {
 #include "timer.chrono.h"
 #endif
 
+#ifdef MAC
+#include "timer.chrono.h"
+#endif
+
 #ifdef WINDOWS
 #include "timer.chrono.h"
 #endif


### PR DESCRIPTION
+ Avoid clash with built-in OFF_MAX macro.
+ Update Makefile to support Linux and Mac. Mac using g++-13 that is current version installed by Homebrew and added include flags for Homebrew to link SDL.
+ Mac uses the same save manager as Linux.
+ Add Mac install instructions to README.