### PR TITLE
Squash several -Wformat-security warnings

### DIFF
--- a/src/galaxy/planet.cpp
+++ b/src/galaxy/planet.cpp
@@ -2187,7 +2187,7 @@ bool Planet::do_academy_immigration(const char* source_name) {
         return false;
     }
 
-    snprintf(s, PLANET_MAX_NAME+1, source_name);
+    snprintf(s, PLANET_MAX_NAME+1, "%s", source_name);
     ++academy_sources_this_month_head;
 
     return true;

--- a/src/mode/galaxy_map.cpp
+++ b/src/mode/galaxy_map.cpp
@@ -2713,8 +2713,8 @@ ExodusMode GalaxyMap::month_pass_ai_update() {
             if (!(FEATURE(EF_CHARACTERS)) && onein(1000)) {
                 char oldname[MAX_PLAYER_NAME];
                 char oldfullname[MAX_PLAYER_FULLNAME];
-                snprintf(oldname, MAX_PLAYER_NAME, player->get_name());
-                snprintf(oldfullname, MAX_PLAYER_FULLNAME, player->get_full_name());
+                snprintf(oldname, MAX_PLAYER_NAME, "%s", player->get_name());
+                snprintf(oldfullname, MAX_PLAYER_FULLNAME, "%s", player->get_full_name());
                 Gender oldgender = player->get_gender();
                 if (exostate().kill(player)) {
                     audio_manager.target_music(mpart2mus(9));
@@ -5618,7 +5618,7 @@ void GalaxyMap::discover_species_bulletin(Planet* p) {
         int w = 0;
         int lim = (1 + RND(2));
         for (int i = 0; i < lim; ++i) {
-            w += snprintf(name+w, sizeof(name)-w, d0[rand()%20]);
+            w += snprintf(name+w, sizeof(name)-w, "%s", d0[rand()%20]);
             if (onein(4) && (i+1 < lim)) {
                 w += snprintf(name+w, sizeof(name)-w, "-");
             }
@@ -5672,7 +5672,7 @@ void GalaxyMap::discover_species_bulletin(Planet* p) {
         int w = 0;
         int lim = (1 + RND(2));
         for (int i = 0; i < lim; ++i) {
-            w += snprintf(name+w, sizeof(name)-w, d0[rand()%20]);
+            w += snprintf(name+w, sizeof(name)-w, "%s", d0[rand()%20]);
             if (onein(4) && (i+1 < lim)) {
                 w += snprintf(name+w, sizeof(name)-w, "-");
             }

--- a/src/mode/lunar_battle_prep.cpp
+++ b/src/mode/lunar_battle_prep.cpp
@@ -616,9 +616,9 @@ ExodusMode LunarBattlePrep::update(float delta) {
                 }
 
                 draw_panel();
-                snprintf(text0, sizeof(text0), t0);
-                snprintf(text1, sizeof(text1), t1);
-                snprintf(text2, sizeof(text2), t2);
+                snprintf(text0, sizeof(text0), "%s", t0);
+                snprintf(text1, sizeof(text1), "%s", t1);
+                snprintf(text2, sizeof(text2), "%s", t2);
                 snprintf(text4, sizeof(text4), "(%dMC)", OFFICER_UPGRADE_COST);
                 draw_text();
 

--- a/src/mode/planet_status.cpp
+++ b/src/mode/planet_status.cpp
@@ -119,11 +119,9 @@ void PlanetStatus::enter() {
         strncpy(agri, "None", 20);
     } else {
         if (p->agri_sufficient()) {
-            const char* t = ENHANCED() ? "Sufficient" : "Well";
-            snprintf(agri, 20, t);
+            snprintf(agri, 20, ENHANCED() ? "Sufficient" : "Well");
         } else {
-            const char* t = ENHANCED() ? "Insufficient" : "Not sufficient";
-            snprintf(agri, 20, t);
+            snprintf(agri, 20, ENHANCED() ? "Insufficient" : "Not sufficient");
         }
     }
 

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -229,7 +229,7 @@ struct StarMarker : public Saveable {
     }
 
     void set_tag(const char* new_marker) {
-        snprintf(tag, MAX_MARKER, new_marker);
+        snprintf(tag, MAX_MARKER, "%s", new_marker);
     }
 };
 

--- a/src/save/save.linux.cpp
+++ b/src/save/save.linux.cpp
@@ -15,7 +15,7 @@ const char* SaveManagerLinux::get_save_dir() {
     const char *data_home = getenv("XDG_DATA_HOME");
 
     if (data_home) {
-        snprintf(save_dir, sizeof(save_dir), data_home);
+        snprintf(save_dir, sizeof(save_dir), "%s", data_home);
     } else {
         const char *home = getenv("XDG_DATA_HOME");
 

--- a/src/save/saveable.h
+++ b/src/save/saveable.h
@@ -55,7 +55,7 @@
 #define LOAD_NUM(j, k) k = (decltype(k))(cJSON_GetObjectItemCaseSensitive(j, #k)->valueint)
 #define LOAD_DOUBLE(j, k) k = (decltype(k))(cJSON_GetObjectItemCaseSensitive(j, #k)->valuedouble)
 #define LOAD_BOOL(j, k) k = (cJSON_GetObjectItemCaseSensitive(j, #k)->valueint != 0)
-#define LOAD_STR(j, k) snprintf(k, sizeof(k), cJSON_GetObjectItemCaseSensitive(j, #k)->valuestring)
+#define LOAD_STR(j, k) snprintf(k, sizeof(k), "%s", cJSON_GetObjectItemCaseSensitive(j, #k)->valuestring)
 #define LOAD_ENUM(j, k) k = (decltype(k))(cJSON_GetObjectItemCaseSensitive(j, #k)->valueint)
 
 #define LOAD_SAVEABLE(j, k) { \

--- a/src/state/exodus_state.cpp
+++ b/src/state/exodus_state.cpp
@@ -263,6 +263,7 @@ void ExodusState::init(GameConfig config) {
         snprintf(
             players[i].full_name,
             MAX_PLAYER_FULLNAME + 1,
+            "%s",
             fullname);
         players[i].guild_title = GUILDTITLE_None;
         players[i].dead = false;

--- a/src/state/planet_report.cpp
+++ b/src/state/planet_report.cpp
@@ -15,7 +15,7 @@ PlanetReport& PlanetReport::operator=(const PlanetReport& other) {
 
     items = other.items;
     for (int i = 0; i < other.items; ++i) {
-        snprintf(content[i], REPORT_LINE_MAX, other.content[i]);
+        snprintf(content[i], REPORT_LINE_MAX, "%s", other.content[i]);
     }
 
     event_mask = other.event_mask;


### PR DESCRIPTION
This squashes a bunch of `-Wformat-security` warnings that I see with my compiler version.

```
gcc --version
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
```

Sample warning text:

```
warning: format not a string literal and no format arguments [-Wformat-security]
  619 |                 snprintf(text0, sizeof(text0), t0);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

It should make it more robust against e.g. a player name containing `%s` too.