### PR TITLE
Mark Logger::fatal as noreturn

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -3,6 +3,8 @@
 
 #include <cstdarg>
 
+#include "util/util.h"
+
 namespace Log {
 
     enum Level {VERBOSE, DEBUG, INFO, WARN, ERROR, FATAL};
@@ -18,7 +20,7 @@ namespace Log {
             void info(const char* fmt, ...);
             void warn(const char* fmt, ...);
             void error(const char* fmt, ...);
-            void fatal(const char* fmt, ...);
+            NORETURN void fatal(const char* fmt, ...);
             void set_level(Level);
         private:
             void vlog(Log::Level, const char*, va_list);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -1,0 +1,10 @@
+#ifndef GUARD_UTIL_UTIL_H
+#define GUARD_UTIL_UTIL_H
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define NORETURN [[noreturn]]
+#else
+#define NORETURN __attribute__((noreturn))
+#endif
+
+#endif


### PR DESCRIPTION
This squashes some bogus `-Warray-bounds` warnings by helping the compiler understand what's happened.

These are the squashed warnings:

```
In member function ‘OfficerQuality Player::get_officer(Officer)’,
    inlined from ‘const char* Player::get_officer_title(Officer)’ at src/player/player.cpp:1398:39:
src/player/player.cpp:1018:24: warning: array subscript 5 is above array bounds of ‘OfficerQuality [5]’ [-Warray-bounds=]
 1018 |     return officers[off];
      |            ~~~~~~~~~~~~^
src/player/player.h: In member function ‘const char* Player::get_officer_title(Officer)’:
src/player/player.h:594:24: note: while referencing ‘Player::officers’
  594 |         OfficerQuality officers[OFFICER_MAX];  // Orig: Ps%
      |                        ^~~~~~~~
In member function ‘OfficerQuality Player::get_officer(Officer)’,
    inlined from ‘const char* Player::get_officer_name(Officer)’ at src/player/player.cpp:1402:38:
src/player/player.cpp:1018:24: warning: array subscript 5 is above array bounds of ‘OfficerQuality [5]’ [-Warray-bounds=]
 1018 |     return officers[off];
      |            ~~~~~~~~~~~~^
src/player/player.h: In member function ‘const char* Player::get_officer_name(Officer)’:
src/player/player.h:594:24: note: while referencing ‘Player::officers’
  594 |         OfficerQuality officers[OFFICER_MAX];  // Orig: Ps%
      |                        ^~~~~~~~
In member function ‘OfficerQuality Player::get_officer(Officer)’,
    inlined from ‘const char* Player::get_officer_title_and_name(Officer)’ at src/player/player.cpp:1406:48:
src/player/player.cpp:1018:24: warning: array subscript 5 is above array bounds of ‘OfficerQuality [5]’ [-Warray-bounds=]
 1018 |     return officers[off];
      |            ~~~~~~~~~~~~^
src/player/player.h: In member function ‘const char* Player::get_officer_title_and_name(Officer)’:
src/player/player.h:594:24: note: while referencing ‘Player::officers’
  594 |         OfficerQuality officers[OFFICER_MAX];  // Orig: Ps%
      |                        ^~~~~~~~
```